### PR TITLE
Update to the latest veraison version

### DIFF
--- a/lib/ratls/ratls/src/error.rs
+++ b/lib/ratls/ratls/src/error.rs
@@ -20,7 +20,7 @@ pub enum RaTlsError {
     Base64DecodeError(DecodeError),
     Pkcs8Error(pkcs8::Error),
     Pkcs8SpkiError(pkcs8::spki::Error),
-    RcgenError(rcgen::RcgenError),
+    RcgenError(rcgen::Error),
     Asn1DecodeError(simple_asn1::ASN1DecodeErr),
     Asn1EncodeError(simple_asn1::ASN1EncodeErr),
     CertSignError(SignError),
@@ -84,8 +84,8 @@ impl From<pkcs8::spki::Error> for RaTlsError {
     }
 }
 
-impl From<rcgen::RcgenError> for RaTlsError {
-    fn from(value: rcgen::RcgenError) -> Self {
+impl From<rcgen::Error> for RaTlsError {
+    fn from(value: rcgen::Error) -> Self {
         Self::RcgenError(value)
     }
 }

--- a/lib/ratls/veraison-verifier/Cargo.toml
+++ b/lib/ratls/veraison-verifier/Cargo.toml
@@ -11,4 +11,6 @@ ratls = { path = "../ratls" }
 reqwest = { version = "*", features = ["blocking", "json"] }
 serde = { version = "*", features = ["derive", "alloc"] }
 serde_json = { version = "*", features = ["alloc"] }
-ear = { path = "../rust-ear" }
+ear = { git = "https://github.com/veraison/rust-ear" }
+rust-rsi = { path = "../../rust-rsi" }
+base64 = { version = "*", features = ["alloc"] }

--- a/lib/ratls/veraison-verifier/src/error.rs
+++ b/lib/ratls/veraison-verifier/src/error.rs
@@ -8,7 +8,8 @@ pub enum VeraisonTokenVeriferError {
     VeraisonDidntProvideNextLocation,
     LocationHeaderIsNotAString,
     AttestationResultsVerificationError(ear::Error),
-    SubmoduleDoesNotAffirm(String)
+    SubmoduleDoesNotAffirm(String),
+    TokenParsingError(rust_rsi::TokenError)
 }
 
 impl From<reqwest::Error> for VeraisonTokenVeriferError {
@@ -20,6 +21,12 @@ impl From<reqwest::Error> for VeraisonTokenVeriferError {
 impl From<ear::Error> for VeraisonTokenVeriferError {
     fn from(value: ear::Error) -> Self {
         Self::AttestationResultsVerificationError(value)
+    }
+}
+
+impl From<rust_rsi::TokenError> for VeraisonTokenVeriferError {
+    fn from(value: rust_rsi::TokenError) -> Self {
+        Self::TokenParsingError(value)
     }
 }
 

--- a/tools/rocli/src/main.rs
+++ b/tools/rocli/src/main.rs
@@ -46,6 +46,10 @@ enum Commands {
         /// Path to Cpak public PEM
         #[arg(short, long)]
         cpak: Vec<String>,
+
+        /// Type of the provided key
+        #[arg(short, long)]
+        cpak_type: Vec<String>
     },
 
     refvals { },
@@ -66,7 +70,7 @@ fn main() -> Result<(), RocliError> {
     let token = verify_token(read_bytes(cli.token)?.as_slice(), None)?;
 
     let comid = match cli.command {
-        Commands::endorsements { cpak } => make_endorsements(cpak, token, config)?,
+        Commands::endorsements { cpak, cpak_type } => make_endorsements(cpak, cpak_type, token, config)?,
         Commands::refvals { } => make_refvals(token, config)?,
         Commands::corim { } => make_corim(token, config)?
     };

--- a/tools/rocli/src/subcmds.rs
+++ b/tools/rocli/src/subcmds.rs
@@ -1,16 +1,16 @@
 use rust_rsi::{AttestationClaims, PlatClaims, PlatSwComponent};
 use crate::tags::{Comid, Environment, AttesterVerificationKeys,
-    VerificationKey, Triples, Config, ReferenceValue, Corim, Output, Measurement};
+    VerificationKey, Triples, Config, ReferenceValue, Corim, Output, Measurement, TypeValue};
 use crate::tools::read_string;
 use crate::error::RocliError;
 
-pub(crate) fn make_endorsements(cpak: Vec<String>, token: AttestationClaims, config: Config) -> Result<Output, RocliError> {
+pub(crate) fn make_endorsements(cpak: Vec<String>, cpak_type: Vec<String>, token: AttestationClaims, config: Config) -> Result<Output, RocliError> {
     let plat_claims = PlatClaims::from_raw_claims(&token.platform_claims.token_claims)?;
     let mut keys = Vec::new();
 
-    for cpak in cpak.into_iter() {
-        let key = read_string(cpak)?;
-        keys.push(VerificationKey { key });
+    for (ty, val) in cpak_type.into_iter().zip(cpak.into_iter()){
+        let key = read_string(val)?;
+        keys.push(TypeValue { ty, val: key });
     }
     let mut envir: Environment = plat_claims.into();
 

--- a/tools/rocli/src/tags.rs
+++ b/tools/rocli/src/tags.rs
@@ -69,7 +69,7 @@ pub(crate) struct AttesterVerificationKeys {
     pub environment: Environment,
 
     #[serde(rename = "verification-keys")]
-    pub verification_keys: Vec<VerificationKey>
+    pub verification_keys: Vec<TypeValue>
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This PR updates all component to be compatible with what was changed in Veraison project since last summer. In a nut shell:
* The Veraison API client was updated as now the backend requires the session nonce to be equal to the realm challenge from the attested token.
* The Corim passed to Veraison during provisioning of claims has now an additional field stating the cpak key format.
* I changed the dependencies to use the `rust-ear` directly from the Veraison upstream as they finally fixed it.